### PR TITLE
Failing when requesting siblings

### DIFF
--- a/lib/closure_tree/acts_as_tree.rb
+++ b/lib/closure_tree/acts_as_tree.rb
@@ -120,7 +120,7 @@ module ClosureTree
     end
 
     def self_and_siblings
-      self.class.scoped.where(:parent => parent)
+      self.class.scoped.where(:parent_id => parent)
     end
 
     def siblings


### PR DESCRIPTION
Hi,
closure_tree was crashing when requesting siblings for a specific row.

1.9.3-p125 :006 > creativity = Tag.find 10
  Tag Load (0.4ms)  SELECT `tags`.\* FROM `tags` WHERE `tags`.`id` = 10 ORDER BY tags.title ASC LIMIT 1
 => #<Tag id: 10, title: "creativity", description: "", created_at: "2012-04-17 11:59:18", updated_at: "2012-06-04 16:25:01", parent_id: 26, slug: "creativity"> 
1.9.3-p125 :008 > creativity.parent
  Tag Load (0.4ms)  SELECT `tags`.\* FROM `tags` WHERE `tags`.`id` = 26 ORDER BY tags.title ASC LIMIT 1
 => #<Tag id: 26, title: "art", description: "", created_at: "2012-04-17 11:59:18", updated_at: "2012-06-04 16:21:00", parent_id: nil, slug: "art"> 
1.9.3-p125 :009 > creativity.siblings
  Tag Load (0.6ms)  SELECT `tags`.\* FROM `tags` WHERE `tags`.`parent` = 26 AND (`tags`.id != 10) ORDER BY tags.title ASC
ActiveRecord::StatementInvalid: Mysql2::Error: Unknown column 'tags.parent' in 'where clause': SELECT `tags`.\* FROM `tags`  WHERE `tags`.`parent` = 26 AND (`tags`.id != 10) ORDER BY tags.title ASC
