### PR TITLE
Specifying the table name

### DIFF
--- a/lib/closure_tree/acts_as_tree.rb
+++ b/lib/closure_tree/acts_as_tree.rb
@@ -21,7 +21,7 @@ module ClosureTree
       self.hierarchy_class = Object.const_set hierarchy_class_name, Class.new(ActiveRecord::Base)
 
       self.hierarchy_class.class_eval <<-RUBY
-        self.table_name = hierarchy_class_name.tableize
+        self.table_name = "#{hierarchy_class_name.tableize}"
         belongs_to :ancestor, :class_name => "#{ct_class.to_s}"
         belongs_to :descendant, :class_name => "#{ct_class.to_s}"
         attr_accessible :ancestor, :descendant, :generations


### PR DESCRIPTION
Seems that using the `class_factory` pattern didin't agree with the table name, as when I ran my app with this gem, the table name for the `hierarchy_class` was always empty. So this PR sets the table name.

thx
