### PR TITLE
#siblings dies when no :order specified

### DIFF
--- a/lib/closure_tree/acts_as_tree.rb
+++ b/lib/closure_tree/acts_as_tree.rb
@@ -182,7 +182,7 @@ module ClosureTree
 
     def self_and_siblings
       s = ct_base_class.where(parent_column_sym => parent)
-      quoted_order_column ? s.order(quoted_order_column) : s
+      order_option.present? ? s.order(quoted_order_column) : s
     end
 
     def siblings


### PR DESCRIPTION
Fix an issue where `#siblings` crashes with no method error for `#quoted_order_column` when `acts_as_tree` was called with no `:order` option.
