### PR TITLE
Use :pluck

### DIFF
--- a/lib/closure_tree/acts_as_tree.rb
+++ b/lib/closure_tree/acts_as_tree.rb
@@ -352,7 +352,7 @@ module ClosureTree
     end
 
     def ids_from(scope)
-      scope.uniq.pluck(:id)
+      scope.try(:pluck, :id) || scope.select(:id).collect(&:id)
     end
 
 


### PR DESCRIPTION
Rails 3.2 introduced the [pluck method](http://api.rubyonrails.org/classes/ActiveRecord/Calculations.html#method-i-pluck). This prevents you from having to load up full AR model instances just to grab the id field.
