### PR TITLE
Use quote_table_name instead of quote_column_name to quote table names	

### DIFF
--- a/lib/closure_tree/acts_as_tree.rb
+++ b/lib/closure_tree/acts_as_tree.rb
@@ -435,7 +435,7 @@ module ClosureTree
     end
 
     def quoted_hierarchy_table_name
-      connection.quote_column_name hierarchy_table_name
+      connection.quote_table_name hierarchy_table_name
     end
 
     def quoted_parent_column_name
@@ -486,7 +486,7 @@ module ClosureTree
     end
 
     def quoted_table_name
-      connection.quote_column_name ct_table_name
+      connection.quote_table_name ct_table_name
     end
 
     def remove_prefix_and_suffix(table_name)


### PR DESCRIPTION
Hi,

when table names are referenced using the schema they're contained in (e.g. `history.foobar`), AR's `quote_column_name` yields `"history.foobar"`, while the correct quoting is `"history"."foobar"` - speaking of Postgres.

So, I've changed the code to use `quote_table_name` when applicable.

Cheers,

~Marcello
