### PR TITLE
Add support for strong_parameters

### DIFF
--- a/lib/closure_tree/acts_as_tree.rb
+++ b/lib/closure_tree/acts_as_tree.rb
@@ -50,7 +50,9 @@ module ClosureTree
         :class_name => ct_class.to_s,
         :foreign_key => parent_column_name
 
-      attr_accessible :parent
+      unless defined?(ActiveModel::ForbiddenAttributesProtection) && ancestors.include?(ActiveModel::ForbiddenAttributesProtection)
+        attr_accessible :parent
+      end
 
       has_many :children, with_order_option(
         :class_name => ct_class.to_s,


### PR DESCRIPTION
Don't set attr_accessible if `ActiveModel::ForbiddenAttributesProtection` is mixed in to the class.

strong_parameters is available as a gem now, but will be the default in Rails 4.
