### PR TITLE
Use `build_nested_hash` to create hash trees

### DIFF
--- a/lib/closure_tree/acts_as_tree.rb
+++ b/lib/closure_tree/acts_as_tree.rb
@@ -106,7 +106,7 @@ module ClosureTree
                   MAX(#{quoted_hierarchy_table_name}.generations) AS depth
                 FROM #{quoted_hierarchy_table_name}
                 GROUP BY #{quoted_hierarchy_table_name}.descendant_id
-                HAVING depth <= #{limit_depth - 1}
+                HAVING MAX(#{quoted_hierarchy_table_name}.generations) <= #{limit_depth - 1}
               ) AS generation_depth
               ON #{quoted_hierarchy_table_name}.descendant_id = generation_depth.descendant_id
             SQL


### PR DESCRIPTION
Comments and code from: https://github.com/elskwid/closure_tree/commit/a57b3b84aa0e1060de32de6fdf7a7a9ac843b50f

This implements `build_nested_hash` method that takes a block that returns a scope and makes a pretty nested hash. A few tweaks in this version,
- Returns an empty hash if a block is not given this is just a little clearer using `return` instead of the `if`
- Class method is a little noisier given we're working with the nested select
- Default `limit_depth` is removed as discussed here: https://github.com/elskwid/closure_tree/commit/a57b3b84aa0e1060de32de6fdf7a7a9ac843b50f#commitcomment-2367578
