### PR TITLE
WHERE ... IN / subselects

### DIFF
--- a/lib/closure_tree/acts_as_tree.rb
+++ b/lib/closure_tree/acts_as_tree.rb
@@ -263,16 +263,17 @@ module ClosureTree
     end
 
     def find_all_by_generation(generation_level)
-      s = ct_base_class.joins(<<-SQL)
-          INNER JOIN (
-            SELECT descendant_id
-            FROM #{quoted_hierarchy_table_name}
-            WHERE ancestor_id = #{self.id}
-            GROUP BY 1
-            HAVING MAX(#{quoted_hierarchy_table_name}.generations) = #{generation_level.to_i}
-          ) AS descendants ON (#{quoted_table_name}.#{ct_base_class.primary_key} = descendants.descendant_id)
+      # Use subselect since we don't need data from the other table
+      scope = ct_base_class.where(<<-SQL)
+        #{quoted_table_name}.#{ct_base_class.primary_key} IN (
+          SELECT #{quoted_hierarchy_table_name}.descendant_id
+          FROM #{quoted_hierarchy_table_name}
+          WHERE #{quoted_hierarchy_table_name}.ancestor_id = #{self.id}
+          AND #{quoted_hierarchy_table_name}.generations = #{generation_level.to_i}
+        )
       SQL
-      order_option ? s.order(order_option) : s
+
+      order_option ? scope.order(order_option) : scope
     end
 
     def hash_tree(options = {})


### PR DESCRIPTION
Extracted these from my spike last night.

Rework `self.leaves` and `#find_all_by_generation` to use `IN` with simple subselects instead of joining to them. 
- These queries are more what we're trying to do in the methods - filter result sets. 
- They provide performance improvements as the dataset grows in size. 
- They are less likely to cause conflicts with other scopes on the data.
