### PR TITLE
Committing large transactions is very slow

### DIFF
--- a/lib/closure_tree/acts_as_tree.rb
+++ b/lib/closure_tree/acts_as_tree.rb
@@ -40,6 +40,9 @@ module ClosureTree
           self.attributes == comparison_object.attributes
         end
         alias :eql? :==
+        def hash
+          attributes.hash
+        end
       RUBY
 
       self.hierarchy_class.table_name = hierarchy_table_name

--- a/spec/tag_spec.rb
+++ b/spec/tag_spec.rb
@@ -130,6 +130,15 @@ shared_examples_for "Tag (1)" do
         TagHierarchy.find_all_by_ancestor_id(@root.id).should == root_hiers
         TagHierarchy.find_all_by_descendant_id(@root.id).should == root_hiers
       end
+
+      it "should have different hash codes for each hierarchy model" do
+        hashes = TagHierarchy.all.map(&:hash)
+        hashes.should =~ hashes.uniq
+      end
+
+      it "should return the same hash code for equal hierarchy models" do
+        TagHierarchy.first.hash.should == TagHierarchy.first.hash
+      end
     end
 
     it "performs as the readme says it does" do


### PR DESCRIPTION
Committing transactions involving large numbers of hierarchy model classes is very slow. On my machine committing a transaction involving 1,111 hierarchy model classes takes 5.2 secs.

The problem appears to be that the hierarchy model class overrides == and eql? but not hash. Thus all model instances hash to the same value making the uniq call on the array of modified ActiveRecord instances in ActiveRecord::ConnectionAdapters::DatabaseStatements.commit_transaction_records() very slow. For my test case with 1,111 hierarchy model instances, the call to uniq() makes 2,466,420 calls to the hierarchy model eql? method. If I implement the hierarchy model hash method as follows this drops to 4,326 calls and the commit completes in 0.06 secs:

```
def hash
  attributes.hash
end
```
