### PR TITLE
prevent faulty SQL statement when #siblings is called on an unsaved records

### DIFF
--- a/lib/closure_tree/model.rb
+++ b/lib/closure_tree/model.rb
@@ -244,6 +244,7 @@ module ClosureTree
     end
 
     def without_self(scope)
+      return scope if self.new_record?
       scope.where(["#{quoted_table_name}.#{ct_base_class.primary_key} != ?", self])
     end
 

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -126,6 +126,18 @@ describe "empty db" do
     b1.siblings.should =~ [b2, b3]
   end
 
+  context "when a user is not yet saved" do
+    it "supports siblings" do
+      User.order_option.should be_nil
+      a = User.create(:email => "a")
+      b1 = a.children.new(:email => "b1")
+      b2 = a.children.create(:email => "b2")
+      b3 = a.children.create(:email => "b3")
+      a.siblings.should be_empty
+      b1.siblings.should =~ [b2, b3]
+    end
+  end
+
   it "properly nullifies descendents" do
     c = User.find_or_create_by_path %w(a b c)
     b = c.parent


### PR DESCRIPTION
Allow #siblings to be called on unsaved models. This becomes relevant when #siblings is used in custom validations (which will run before the model has an ID). This PR fixes the faulty SQL that is constructed by #siblings when the model hasn't yet received an ID.
