### PR TITLE
Fix #56 - Avoid loading the ancestor and descendant in the hierarchy model equals method.

### DIFF
--- a/lib/closure_tree/acts_as_tree.rb
+++ b/lib/closure_tree/acts_as_tree.rb
@@ -36,7 +36,7 @@ module ClosureTree
         belongs_to :descendant, :class_name => "#{ct_class.to_s}"
         attr_accessible :ancestor, :descendant, :generations
         def ==(other)
-          self.class == other.class && ancestor == other.ancestor && descendant == other.descendant
+          self.class == other.class && ancestor_id == other.ancestor_id && descendant_id == other.descendant_id
         end
         alias :eql? :==
         def hash


### PR DESCRIPTION
Fix for #56 - In the hierarchy model equals method compare the ancestor and descendant models by id so they don't need to be loaded. 
