### PR TITLE
Postgis Adapter Support.

### DIFF
--- a/lib/closure_tree/numeric_order_support.rb
+++ b/lib/closure_tree/numeric_order_support.rb
@@ -3,7 +3,7 @@ module ClosureTree
 
     def self.adapter_for_connection(connection)
       case connection.adapter_name.downcase.to_sym
-        when :postgresql
+        when :postgresql, :postgis #Postgis is based on Postgresql
           ::ClosureTree::NumericOrderSupport::PostgreSQLAdapter
         when :mysql, :mysql2
           ::ClosureTree::NumericOrderSupport::MysqlAdapter


### PR DESCRIPTION
"The activerecord-postgis-adapter is a plugin that provides access to features of the PostGIS geospatial database from ActiveRecord. Technically, it extends the standard postgresql adapter to provide support for the spatial data types and features added by the PostGIS extension."
https://github.com/dazuma/activerecord-postgis-adapter

ClosureTree will not use the Lock-\* when Postgis Adapter is used now.
