### PR TITLE
Fix _ct.scope_with_order when no order_column is specified

### DIFF
--- a/lib/closure_tree/support.rb
+++ b/lib/closure_tree/support.rb
@@ -68,7 +68,11 @@ module ClosureTree
     end
 
     def scope_with_order(scope, additional_order_by = nil)
-      order_option? ? scope.order(*([additional_order_by, order_by].compact)) : scope
+      if order_option?
+        scope.order(*([additional_order_by, order_by].compact))
+      else
+        additional_order_by ? scope.order(additional_order_by) : scope
+      end
     end
 
     # lambda-ize the order, but don't apply the default order_option


### PR DESCRIPTION
_ct.scope_with_order should accept `additional_order_by` attribute even when no order_column is specified. It avoids failing Model.hash_tree when the tree_scope isn't ordered by generations and building the tree will fail at `hash_tree.rb:52` because the parent_id isn't yet key in the hash.
