### PR TITLE
Support ordering for root level items

### DIFF
--- a/lib/closure_tree/numeric_deterministic_ordering.rb
+++ b/lib/closure_tree/numeric_deterministic_ordering.rb
@@ -112,7 +112,8 @@ module ClosureTree
         self.order_value += 1
         self.save!
       end
-      parent.add_child(sibling) # <- this causes sibling to be saved.
+      sibling.parent = self.parent
+      sibling.save!
     end
   end
 end


### PR DESCRIPTION
When sorting root level items or moving item up to the root level `add_item` is called on nil.
