### PR TITLE
pluralizing migration class name

### DIFF
--- a/lib/generators/closure_tree/migration_generator.rb
+++ b/lib/generators/closure_tree/migration_generator.rb
@@ -19,7 +19,7 @@ module ClosureTree
       end
 
       def migration_class_name
-        "Create#{ct.hierarchy_class_name}".gsub(/\W/, '')
+        "Create#{ct.hierarchy_class_name.to_s.pluralize}".gsub(/\W/, '')
       end
 
       def ct


### PR DESCRIPTION
`rails g closure_tree:migration tag`

yields a migration file that contains non pluralized class name:

``` ruby
class CreateTagHierarchy
```

which should be:

``` ruby
class CreateTagHierarchies
```

this allows `rake db:migrate` to run correctly
