### PR TITLE
Prevent name collision with other gems: allowing the use of `has_closure_tree`method besides `acts_as_tree`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ for a description of different tree storage algorithms.
 ## Table of Contents
 
 - [Installation](#installation)
+- [Warning](#warning)
 - [Usage](#usage)
 - [Accessing Data](#accessing-data)
 - [Polymorphic hierarchies with STI](#polymorphic-hierarchies-with-sti)
@@ -60,11 +61,15 @@ Note that closure_tree only supports Rails 3.2 and later, and has test coverage 
 
 2.  Run `bundle install`
 
-3.  Add `acts_as_tree` to your hierarchical model:
+3.  Add `acts_as_tree` or `has_closure_tree` (alias of the same method) to your hierarchical model:
 
     ```ruby
     class Tag < ActiveRecord::Base
       acts_as_tree
+    end
+
+    class AnotherTag < ActiveRecord::Base
+      has_closure_tree
     end
     ```
 
@@ -72,6 +77,8 @@ Note that closure_tree only supports Rails 3.2 and later, and has test coverage 
     
     Make sure you add `acts_as_tree` **after** `attr_accessible` and
     `self.table_name =` lines in your model.
+
+    If you have other hierarchical gems in your stack, `acts_as_tree` method may not be safe to use. See the [Warning](#warning) section bellow.
 
 4.  Add a migration to add a `parent_id` column to the hierarchical model.
     You may want to also [add a column for deterministic ordering of children](#sort_order), but that's optional.
@@ -100,6 +107,12 @@ Note that closure_tree only supports Rails 3.2 and later, and has test coverage 
     `tag_hierarchies` table will be truncated and rebuilt.
 
     If you're starting from scratch you don't need to call `rebuild!`.
+
+## Warning
+
+The preferred method is `acts_as_tree`. However, other gems (like [ancestry](https://github.com/stefankroes/ancestry) or [acts_as_tree](https://github.com/amerine/acts_as_tree)) may use that method name too. If you have those gems as dependencies, use the alternative `has_closure_tree` method.
+
+Bear in mind that using multiple hierarchy gems in the same model may not be safe. In fact, it's a safe bet to assume that it will cause all sorts of pain, suffering, and havoc. Avoid it.
 
 ## Usage
 

--- a/lib/closure_tree/acts_as_tree.rb
+++ b/lib/closure_tree/acts_as_tree.rb
@@ -2,7 +2,7 @@ require 'with_advisory_lock'
 
 module ClosureTree
   module ActsAsTree
-    def acts_as_tree(options = {})
+    def has_closure_tree(options = {})
       options.assert_valid_keys(
         :parent_column_name,
         :dependent,
@@ -35,5 +35,7 @@ module ClosureTree
       # Support Heroku's database-less assets:precompile pre-deploy step:
       raise e unless ENV['DATABASE_URL'].to_s.include?('//user:pass@127.0.0.1/') && ENV['RAILS_GROUPS'] == 'assets'
     end
+
+    alias_method :acts_as_tree, :has_closure_tree
   end
 end

--- a/spec/db/models.rb
+++ b/spec/db/models.rb
@@ -1,7 +1,7 @@
 require 'uuidtools'
 
 class Tag < ActiveRecord::Base
-  acts_as_tree :dependent => :destroy, :order => :name
+  has_closure_tree :dependent => :destroy, :order => :name
   before_destroy :add_destroyed_tag
   attr_accessible :name, :title if _ct.use_attr_accessible?
 


### PR DESCRIPTION
Scenario: one of your dependencies uses other gem like Ancestry, while you want to use this gem for its multiple benefits. Even if that dependency uses the `has_ancestry` method instead of the `acts_as_tree` method, it will overwrite ClosureTree's acts_as_tree, render it useless. If we can still use another method like `has_closure_tree`, we can still work with this.

This way, the user can choose between using `has_closure_tree` (more intention revealing name in terms of what tool we want to use, IMO) or the generic `acts_as_tree` as before.

I changed one of the models of the specs to use the `has_closure_tree` method while leaving the rest using the `acts_as_tree` method to ensure that everything keeps working as expected.
