### PR TITLE
Performance tweaks

### DIFF
--- a/lib/closure_tree/finders.rb
+++ b/lib/closure_tree/finders.rb
@@ -79,6 +79,8 @@ module ClosureTree
           INNER JOIN (
             SELECT ancestor_id
             FROM #{_ct.quoted_hierarchy_table_name}
+            INNER JOIN (#{self.all.to_sql}) AS outer_table
+              ON outer_table.#{primary_key} = #{_ct.quoted_hierarchy_table_name}.ancestor_id
             GROUP BY 1
             HAVING MAX(#{_ct.quoted_hierarchy_table_name}.generations) = 0
           ) AS leaves ON (#{_ct.quoted_table_name}.#{primary_key} = leaves.ancestor_id)

--- a/lib/closure_tree/hash_tree.rb
+++ b/lib/closure_tree/hash_tree.rb
@@ -31,6 +31,8 @@ module ClosureTree
           INNER JOIN (
             SELECT descendant_id, MAX(generations) as depth
             FROM #{_ct.quoted_hierarchy_table_name}
+            INNER JOIN (#{self.all.to_sql}) AS outer_table
+              ON outer_table.#{primary_key} = #{_ct.quoted_hierarchy_table_name}.descendant_id
             GROUP BY descendant_id
             #{having_clause}
           ) AS generation_depth

--- a/lib/closure_tree/hierarchy_maintenance.rb
+++ b/lib/closure_tree/hierarchy_maintenance.rb
@@ -94,12 +94,13 @@ module ClosureTree
         _ct.connection.execute <<-SQL.strip_heredoc
           DELETE FROM #{_ct.quoted_hierarchy_table_name}
           WHERE descendant_id IN (
+            SELECT #{_ct.quote(id)} AS descendant_id
+            UNION ALL
             SELECT DISTINCT descendant_id
             FROM (SELECT descendant_id
               FROM #{_ct.quoted_hierarchy_table_name}
               WHERE ancestor_id = #{_ct.quote(id)}
             ) AS x )
-            OR descendant_id = #{_ct.quote(id)}
         SQL
       end
     end


### PR DESCRIPTION
We noticed that certain queries using sub selects are fairly slow on a bigger recordset. Our hierarchy table contains 80+ million records causing these queries to take a long time.

The added additional queries avoid the performance issue by minimizing the record sets in the sub selects before the join with the outer table.
