### PR TITLE
Fix `tree.find_by_tree([])`

### DIFF
--- a/lib/closure_tree/finders.rb
+++ b/lib/closure_tree/finders.rb
@@ -112,6 +112,7 @@ module ClosureTree
 
       # Find the node whose +ancestry_path+ is +path+
       def find_by_path(path, attributes = {}, parent_id = nil)
+        return nil if path.blank?
         path = _ct.build_ancestry_attr_path(path, attributes)
         if path.size > _ct.max_join_tables
           return _ct.find_by_large_path(path, attributes, parent_id)

--- a/spec/tag_examples.rb
+++ b/spec/tag_examples.rb
@@ -72,6 +72,42 @@ shared_examples_for Tag do
         expect(tag_class.leaves).to eq([@tag])
       end
 
+      it 'should not be found by passing find_by_path an array of blank strings' do
+        expect(tag_class.find_by_path([''])).to be_nil
+      end
+
+      it 'should not be found by passing find_by_path an empty array' do
+        expect(tag_class.find_by_path([])).to be_nil
+      end
+
+      it 'should not be found by passing find_by_path nil' do
+        expect(tag_class.find_by_path(nil)).to be_nil
+      end
+
+      it 'should not be found by passing find_by_path an empty string' do
+        expect(tag_class.find_by_path('')).to be_nil
+      end
+
+      it 'should not be found by passing find_by_path an array of nils' do
+        expect(tag_class.find_by_path([nil])).to be_nil
+      end
+
+      it 'should not be found by passing find_by_path an array with an additional blank string' do
+        expect(tag_class.find_by_path([@tag.name, ''])).to be_nil
+      end
+
+      it 'should not be found by passing find_by_path an array with an additional nil' do
+        expect(tag_class.find_by_path([@tag.name, nil])).to be_nil
+      end
+
+      it 'should be found by passing find_by_path an array with its name' do
+        expect(tag_class.find_by_path([@tag.name])).to eq @tag
+      end
+
+      it 'should be found by passing find_by_path its name' do
+        expect(tag_class.find_by_path(@tag.name)).to eq @tag
+      end
+
       context 'with child' do
         before do
           @child = tag_class.create!(name: 'tag 2')


### PR DESCRIPTION
Previously `Tag.find_by_tree([])` would return essentially `Tag.first`.
This was confusing as I expected it this should return `nil`.

I've also added a number of similar specs of passing all the blank values I can think of
as `Tag.find_by_tree` didn't seem to already be tested with these various blank values.
