### PR TITLE
Eliminate deprecation warnings in ActiveRecord 5.2

### DIFF
--- a/lib/closure_tree/model.rb
+++ b/lib/closure_tree/model.rb
@@ -13,7 +13,7 @@ module ClosureTree
         touch: _ct.options[:touch],
         optional: true)
 
-      order_by_generations = "#{_ct.quoted_hierarchy_table_name}.generations asc"
+      order_by_generations = Arel.sql("#{_ct.quoted_hierarchy_table_name}.generations ASC")
 
       has_many :children, *_ct.has_many_with_order_option(
         class_name: _ct.model_class.to_s,

--- a/lib/closure_tree/numeric_deterministic_ordering.rb
+++ b/lib/closure_tree/numeric_deterministic_ordering.rb
@@ -65,7 +65,7 @@ module ClosureTree
         node_score = "(1 + anc.#{_ct.quoted_order_column(false)}) * " +
           "power(#{h['total_descendants']}, #{h['max_depth'].to_i + 1} - #{depth_column})"
 
-        "sum(#{node_score})"
+        Arel.sql("SUM(#{node_score})")
       end
 
       def roots_and_descendants_preordered


### PR DESCRIPTION
Starting from Rails 5.2 passing raw SQL to methods like `order` is deprecated and in 6.0 it will be forbidden because of security concerns.

When users sure that passed string is safe, they must wrap it with `Arel.sql`.