### PR TITLE
When using 'oracle_enhanced', remove 'AS' on the table_name alias.

### DIFF
--- a/lib/closure_tree/finders.rb
+++ b/lib/closure_tree/finders.rb
@@ -41,7 +41,7 @@ module ClosureTree
           WHERE ancestor_id = #{_ct.quote(self.id)}
           GROUP BY descendant_id
           HAVING MAX(#{_ct.quoted_hierarchy_table_name}.generations) = #{generation_level.to_i}
-        ) AS descendants ON (#{_ct.quoted_table_name}.#{_ct.base_class.primary_key} = descendants.descendant_id)
+        ) #{ _ct.t_alias_keyword } descendants ON (#{_ct.quoted_table_name}.#{_ct.base_class.primary_key} = descendants.descendant_id)
       SQL
       _ct.scope_with_order(s)
     end
@@ -76,7 +76,7 @@ module ClosureTree
             FROM #{_ct.quoted_hierarchy_table_name}
             GROUP BY ancestor_id
             HAVING MAX(#{_ct.quoted_hierarchy_table_name}.generations) = 0
-          ) AS leaves ON (#{_ct.quoted_table_name}.#{primary_key} = leaves.ancestor_id)
+          ) #{ _ct.t_alias_keyword } leaves ON (#{_ct.quoted_table_name}.#{primary_key} = leaves.ancestor_id)
         SQL
         _ct.scope_with_order(s.readonly(false))
       end
@@ -96,13 +96,13 @@ module ClosureTree
             SELECT #{primary_key} as root_id
             FROM #{_ct.quoted_table_name}
             WHERE #{_ct.quoted_parent_column_name} IS NULL
-          ) AS roots ON (1 = 1)
+          ) #{ _ct.t_alias_keyword }  roots ON (1 = 1)
           INNER JOIN (
             SELECT ancestor_id, descendant_id
             FROM #{_ct.quoted_hierarchy_table_name}
             GROUP BY ancestor_id, descendant_id
             HAVING MAX(generations) = #{generation_level.to_i}
-          ) AS descendants ON (
+          ) #{ _ct.t_alias_keyword }  descendants ON (
             #{_ct.quoted_table_name}.#{primary_key} = descendants.descendant_id
             AND roots.root_id = descendants.ancestor_id
           )
@@ -122,7 +122,7 @@ module ClosureTree
         path.reverse.each_with_index do |ea, idx|
           next_joined_table = "p#{idx}"
           scope = scope.joins(<<-SQL.strip_heredoc)
-            INNER JOIN #{_ct.quoted_table_name} AS #{next_joined_table}
+            INNER JOIN #{_ct.quoted_table_name} #{ _ct.t_alias_keyword } #{next_joined_table}
               ON #{next_joined_table}.#{_ct.quoted_id_column_name} =
  #{connection.quote_table_name(last_joined_table)}.#{_ct.quoted_parent_column_name}
           SQL

--- a/lib/closure_tree/hash_tree_support.rb
+++ b/lib/closure_tree/hash_tree_support.rb
@@ -10,7 +10,7 @@ module ClosureTree
             FROM #{quoted_hierarchy_table_name}
             GROUP BY descendant_id
             #{having_clause}
-          ) AS generation_depth
+          ) #{ t_alias_keyword } generation_depth
             ON #{quoted_table_name}.#{model_class.primary_key} = generation_depth.descendant_id
         SQL
         scope_with_order(scope.joins(generation_depth), 'generation_depth.depth')

--- a/lib/closure_tree/hierarchy_maintenance.rb
+++ b/lib/closure_tree/hierarchy_maintenance.rb
@@ -102,7 +102,7 @@ module ClosureTree
               FROM #{_ct.quoted_hierarchy_table_name}
               WHERE ancestor_id = #{_ct.quote(id)}
                  OR descendant_id = #{_ct.quote(id)}
-            ) AS x )
+            ) #{ _ct.t_alias_keyword } x )
         SQL
       end
     end

--- a/lib/closure_tree/numeric_deterministic_ordering.rb
+++ b/lib/closure_tree/numeric_deterministic_ordering.rb
@@ -78,7 +78,7 @@ module ClosureTree
             SELECT descendant_id, max(generations) AS max_depth
             FROM #{_ct.quoted_hierarchy_table_name}
             GROUP BY descendant_id
-          ) AS depths ON depths.descendant_id = anc.#{_ct.quoted_id_column_name}
+          ) #{ _ct.t_alias_keyword } depths ON depths.descendant_id = anc.#{_ct.quoted_id_column_name}
         SQL
         joins(join_sql)
           .group("#{_ct.quoted_table_name}.#{_ct.quoted_id_column_name}")

--- a/lib/closure_tree/support_attributes.rb
+++ b/lib/closure_tree/support_attributes.rb
@@ -113,7 +113,7 @@ module ClosureTree
 
     # table_name alias keyword , like "AS". When used on table name alias, Oracle Database don't support used 'AS'
     def t_alias_keyword
-      (ActiveRecord::Base.connection.adapter_name.to_sym == :OracleEnhanced) ? "" : :AS
+      (ActiveRecord::Base.connection.adapter_name.to_sym == :OracleEnhanced) ? "" : "AS"
     end
   end
 end

--- a/lib/closure_tree/support_attributes.rb
+++ b/lib/closure_tree/support_attributes.rb
@@ -110,5 +110,10 @@ module ClosureTree
       prefix = include_table_name ? "#{quoted_table_name}." : ""
       "#{prefix}#{connection.quote_column_name(order_column)}"
     end
+
+    # table_name alias keyword , like "AS". When used on table name alias, Oracle Database don't support used 'AS'
+    def t_alias_keyword
+      (ActiveRecord::Base.connection.adapter_name.to_sym == :OracleEnhanced) ? "" : :AS
+    end
   end
 end


### PR DESCRIPTION
When used on table name alias, Oracle Database don't support used 'AS'.