### PR TITLE
Added dont_order_roots option

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,25 @@ root.reload.children.pluck(:name)
 => ["b", "c", "a"]
 ```
 
+### Ordering Roots
+
+With numeric ordering, root nodes are, by default, assigned order values globally across the whole database
+table. So for instance if you have 5 nodes with no parent, they will be ordered 0 through 4 by default.
+If your model represents many separate trees and you have a lot of records, this can cause performance
+problems, and doesn't really make much sense.
+
+You can disable this default behavior by passing `dont_order_roots: true` as an option to your delcaration:
+
+```
+has_closure_tree order: 'sort_order', numeric_order: true, dont_order_roots: true
+```
+
+In this case, calling `prepend_sibling` and `append_sibling` on a root node or calling
+`roots_and_descendants_preordered` on the model will raise a `RootOrderingDisabledError`.
+
+The `dont_order_roots` option will be ignored unless `numeric_order` is set to true.
+
+
 ## Concurrency
 
 Several methods, especially ```#rebuild``` and ```#find_or_create_by_path```, cannot run concurrently correctly.

--- a/lib/closure_tree/has_closure_tree.rb
+++ b/lib/closure_tree/has_closure_tree.rb
@@ -8,6 +8,7 @@ module ClosureTree
         :hierarchy_table_name,
         :name_column,
         :order,
+        :dont_order_roots,
         :numeric_order,
         :touch,
         :with_advisory_lock

--- a/lib/closure_tree/has_closure_tree_root.rb
+++ b/lib/closure_tree/has_closure_tree_root.rb
@@ -1,5 +1,6 @@
 module ClosureTree
   class MultipleRootError < StandardError; end
+  class RootOrderingDisabledError < StandardError; end
 
   module HasClosureTreeRoot
 

--- a/lib/closure_tree/numeric_order_support.rb
+++ b/lib/closure_tree/numeric_order_support.rb
@@ -14,6 +14,7 @@ module ClosureTree
 
     module MysqlAdapter
       def reorder_with_parent_id(parent_id, minimum_sort_order_value = nil)
+        return if parent_id.nil? && dont_order_roots
         min_where = if minimum_sort_order_value
           "AND #{quoted_order_column} >= #{minimum_sort_order_value}"
         else
@@ -31,6 +32,7 @@ module ClosureTree
 
     module PostgreSQLAdapter
       def reorder_with_parent_id(parent_id, minimum_sort_order_value = nil)
+        return if parent_id.nil? && dont_order_roots
         min_where = if minimum_sort_order_value
           "AND #{quoted_order_column} >= #{minimum_sort_order_value}"
         else
@@ -56,6 +58,7 @@ module ClosureTree
 
     module GenericAdapter
       def reorder_with_parent_id(parent_id, minimum_sort_order_value = nil)
+        return if parent_id.nil? && dont_order_roots
         scope = model_class.
           where(parent_column_sym => parent_id).
           order(nulls_last_order_by)

--- a/lib/closure_tree/support_attributes.rb
+++ b/lib/closure_tree/support_attributes.rb
@@ -75,6 +75,10 @@ module ClosureTree
       options[:order]
     end
 
+    def dont_order_roots
+      options[:dont_order_roots] || false
+    end
+
     def nulls_last_order_by
       "-#{quoted_order_column} #{order_by_order(reverse = true)}"
     end

--- a/spec/db/models.rb
+++ b/spec/db/models.rb
@@ -99,6 +99,21 @@ end
 class DirectoryLabel < Label
 end
 
+class LabelWithoutRootOrdering < ActiveRecord::Base
+  # make sure order doesn't matter
+  acts_as_tree :order => :column_whereby_ordering_is_inferred, # <- symbol, and not "sort_order"
+    :numeric_order => true,
+    :dont_order_roots => true,
+    :parent_column_name => "mother_id",
+    :hierarchy_table_name => "label_hierarchies"
+
+  self.table_name = "#{table_name_prefix}labels#{table_name_suffix}"
+
+  def to_s
+    "#{self.class}: #{name}"
+  end
+end
+
 class CuisineType < ActiveRecord::Base
   acts_as_tree
 end


### PR DESCRIPTION
From the proposed Readme text:

By default, root nodes are also assigned order values globally across the whole database table. So for instance if you have 5 nodes with no parent, they will be ordered 0 through 4 by default. If your model represents many separate trees and you have a lot of records, this can cause performance problems, and doesn't really make much sense.

This PR adds an option for disabling this behavior.

This was proposed in issue #282.