### PR TITLE
Use with_connection instead of calling release_connection directly

### DIFF
--- a/lib/closure_tree/has_closure_tree.rb
+++ b/lib/closure_tree/has_closure_tree.rb
@@ -1,38 +1,38 @@
 module ClosureTree
   module HasClosureTree
     def has_closure_tree(options = {})
-      options.assert_valid_keys(
-        :parent_column_name,
-        :dependent,
-        :hierarchy_class_name,
-        :hierarchy_table_name,
-        :name_column,
-        :order,
-        :dont_order_roots,
-        :numeric_order,
-        :touch,
-        :with_advisory_lock
-      )
+      connection_pool.with_connection {
+        options.assert_valid_keys(
+          :parent_column_name,
+          :dependent,
+          :hierarchy_class_name,
+          :hierarchy_table_name,
+          :name_column,
+          :order,
+          :dont_order_roots,
+          :numeric_order,
+          :touch,
+          :with_advisory_lock
+        )
 
-      class_attribute :_ct
-      self._ct = ClosureTree::Support.new(self, options)
+        class_attribute :_ct
+        self._ct = ClosureTree::Support.new(self, options)
 
-      # Auto-inject the hierarchy table
-      # See https://github.com/patshaughnessy/class_factory/blob/master/lib/class_factory/class_factory.rb
-      class_attribute :hierarchy_class
-      self.hierarchy_class = _ct.hierarchy_class_for_model
+        # Auto-inject the hierarchy table
+        # See https://github.com/patshaughnessy/class_factory/blob/master/lib/class_factory/class_factory.rb
+        class_attribute :hierarchy_class
+        self.hierarchy_class = _ct.hierarchy_class_for_model
 
-      # tests fail if you include Model before HierarchyMaintenance wtf
-      include ClosureTree::HierarchyMaintenance
-      include ClosureTree::Model
-      include ClosureTree::Finders
-      include ClosureTree::HashTree
-      include ClosureTree::Digraphs
+        # tests fail if you include Model before HierarchyMaintenance wtf
+        include ClosureTree::HierarchyMaintenance
+        include ClosureTree::Model
+        include ClosureTree::Finders
+        include ClosureTree::HashTree
+        include ClosureTree::Digraphs
 
-      include ClosureTree::DeterministicOrdering if _ct.order_option?
-      include ClosureTree::NumericDeterministicOrdering if _ct.order_is_numeric?
-
-      connection_pool.release_connection
+        include ClosureTree::DeterministicOrdering if _ct.order_option?
+        include ClosureTree::NumericDeterministicOrdering if _ct.order_is_numeric?
+      }
     rescue StandardError => e
       raise e unless ClosureTree.configuration.database_less
     end

--- a/spec/pool_spec.rb
+++ b/spec/pool_spec.rb
@@ -1,6 +1,11 @@
 require 'spec_helper'
 
 describe 'Configuration' do
+  before(:each) do
+    # Make sure we start up with no active connection
+    ActiveRecord::Base.connection_pool.release_connection
+  end
+
   it 'returns connection to the pool after has_closure_tree setup' do
     class TypeDuplicate < ActiveRecord::Base
       self.table_name = "namespace_type#{table_name_suffix}"


### PR DESCRIPTION
The call to release_connection, added in #263, might release a connection that was opened outside of has_closure_tree (if the caller is loaded dynamically in the middle of some other operation). This is especially problematic if the connection has an ongoing transaction, as that transaction will be lost.

This PR changes has_closure_tree to use with_connection instead, which only releases a connection if it was acquired. If a connection already existed prior to the call to has_closure_tree, it won't be released.