### PR TITLE
Remove options restrictions on has_closure_tree_root

### DIFF
--- a/lib/closure_tree/has_closure_tree_root.rb
+++ b/lib/closure_tree/has_closure_tree_root.rb
@@ -5,12 +5,7 @@ module ClosureTree
   module HasClosureTreeRoot
 
     def has_closure_tree_root(assoc_name, options = {})
-      options.assert_valid_keys(
-        :class_name,
-        :foreign_key
-      )
-
-      options[:class_name] ||= assoc_name.to_s.sub(/\Aroot_/, "").classify
+       options[:class_name] ||= assoc_name.to_s.sub(/\Aroot_/, "").classify
       options[:foreign_key] ||= self.name.underscore << "_id"
 
       has_one assoc_name, -> { where(parent: nil) }, options


### PR DESCRIPTION
These restrictions make sense for `has_closure_tree` because it's a fully custom method, whereas `has_closure_tree_root` is a wrapper around `has_one`. Rather than list out all the possible keys that `has_one` can accept, I think we should just remove the restriction. Thoughts?