### PR TITLE
Fix unused variable warnings

### DIFF
--- a/lib/closure_tree/support.rb
+++ b/lib/closure_tree/support.rb
@@ -34,10 +34,11 @@ module ClosureTree
       hierarchy_class = model_class.parent.const_set(short_hierarchy_class_name, Class.new(ActiveRecord::Base))
       use_attr_accessible = use_attr_accessible?
       include_forbidden_attributes_protection = include_forbidden_attributes_protection?
-      hierarchy_class.class_eval <<-RUBY, __FILE__, __LINE__ + 1
+      model_class_name = model_class.to_s
+      hierarchy_class.class_eval do
         include ActiveModel::ForbiddenAttributesProtection if include_forbidden_attributes_protection
-        belongs_to :ancestor, :class_name => "#{model_class}"
-        belongs_to :descendant, :class_name => "#{model_class}"
+        belongs_to :ancestor, class_name: model_class_name
+        belongs_to :descendant, class_name: model_class_name
         attr_accessible :ancestor, :descendant, :generations if use_attr_accessible
         def ==(other)
           self.class == other.class && ancestor_id == other.ancestor_id && descendant_id == other.descendant_id
@@ -46,7 +47,7 @@ module ClosureTree
         def hash
           ancestor_id.hash << 31 ^ descendant_id.hash
         end
-      RUBY
+      end
       hierarchy_class.table_name = hierarchy_table_name
       hierarchy_class
     end

--- a/lib/closure_tree/support_attributes.rb
+++ b/lib/closure_tree/support_attributes.rb
@@ -76,7 +76,7 @@ module ClosureTree
     end
 
     def nulls_last_order_by
-      "-#{quoted_order_column} #{order_by_order(reverse = true)}"
+      "-#{quoted_order_column} #{order_by_order(true)}"
     end
 
     def order_by_order(reverse = false)


### PR DESCRIPTION
1. Unused variable warning in `support.rb` - due to using a `class_eval` string vs a `class_eval` proc.  
2. Unused variable warning in `support_attributes.rb` - not sure what original intention was here - perhaps was to make `nulls_last_order_by` accept reverse, or to use keyword arguments in `order_by_order`