### PR TITLE
Bump version

### DIFF
--- a/lib/closure_tree/version.rb
+++ b/lib/closure_tree/version.rb
@@ -1,3 +1,3 @@
 module ClosureTree
-  VERSION = Gem::Version.new('7.0.0')
+  VERSION = Gem::Version.new('7.1.0')
 end


### PR DESCRIPTION
This is to ensure we get the lowest_common_ancestor function using e.g. `gem 'closure_tree', '~> 7.1'`