### PR TITLE
Update README with Rails 5.2 information

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ closure_tree has some great features:
   * 2 SQL INSERTs on node creation
   * 3 SQL INSERT/UPDATEs on node reparenting
 * __Support for [concurrency](#concurrency)__ (using [with_advisory_lock](https://github.com/ClosureTree/with_advisory_lock))
-* __Tested against ActiveRecord 4.2, 5.0, and 5.1, with  Ruby 2.2 and 2.3__
+* __Tested against ActiveRecord 4.2, 5.0, 5.1 and 5.2, with  Ruby 2.2 and 2.3__
 * Support for reparenting children (and all their descendants)
 * Support for [single-table inheritance (STI)](#sti) within the hierarchy
 * ```find_or_create_by_path``` for [building out heterogeneous hierarchies quickly and conveniently](#find_or_create_by_path)


### PR DESCRIPTION
The [CHANGELOG states](https://github.com/ClosureTree/closure_tree/blob/master/CHANGELOG.md#700) that version 7.0.0 is tested against Rails 5.2, so this should be added to the README.