### PR TITLE
Call Module#module_parent instead of deprecated #parent

### DIFF
--- a/gemfiles/activerecord_4.2.gemfile
+++ b/gemfiles/activerecord_4.2.gemfile
@@ -7,7 +7,7 @@ gem "activerecord", "~> 4.2.0"
 platforms :ruby do
   gem "mysql2", "< 0.5"
   gem "pg", "~> 0.21"
-  gem "sqlite3"
+  gem "sqlite3", "~> 1.3", "< 1.4"
 end
 
 platforms :jruby do

--- a/gemfiles/activerecord_5.0.gemfile
+++ b/gemfiles/activerecord_5.0.gemfile
@@ -7,7 +7,7 @@ gem "activerecord", "~> 5.0.0"
 platforms :ruby do
   gem "mysql2"
   gem "pg"
-  gem "sqlite3"
+  gem "sqlite3", "~> 1.3", "< 1.4"
 end
 
 platforms :jruby do

--- a/lib/closure_tree/support.rb
+++ b/lib/closure_tree/support.rb
@@ -32,7 +32,12 @@ module ClosureTree
     end
 
     def hierarchy_class_for_model
-      hierarchy_class = model_class.parent.const_set(short_hierarchy_class_name, Class.new(ActiveRecord::Base))
+      parent_class = if ActiveSupport.version >= Gem::Version.new('6.0.0.beta1')
+        model_class.module_parent
+      else
+        model_class.parent
+      end
+      hierarchy_class = parent_class.const_set(short_hierarchy_class_name, Class.new(ActiveRecord::Base))
       use_attr_accessible = use_attr_accessible?
       include_forbidden_attributes_protection = include_forbidden_attributes_protection?
       model_class_name = model_class.to_s


### PR DESCRIPTION
To silence the deprecation warning mentioned at https://github.com/ClosureTree/closure_tree/issues/346

So that it is backwards compatible with Rails versions < 6:

- call `module_parent` if ActiveSupport version >= 6.0.0.beta1
- otherwise call `parent`