### PR TITLE
Directly require core_ext for String#strip_heredoc

### DIFF
--- a/gemfiles/activerecord_4.2.gemfile
+++ b/gemfiles/activerecord_4.2.gemfile
@@ -7,7 +7,7 @@ gem "activerecord", "~> 4.2.0"
 platforms :ruby do
   gem "mysql2", "< 0.5"
   gem "pg", "~> 0.21"
-  gem "sqlite3"
+  gem "sqlite3", "~> 1.3", "< 1.4"
 end
 
 platforms :jruby do

--- a/gemfiles/activerecord_5.0.gemfile
+++ b/gemfiles/activerecord_5.0.gemfile
@@ -7,7 +7,7 @@ gem "activerecord", "~> 5.0.0"
 platforms :ruby do
   gem "mysql2"
   gem "pg"
-  gem "sqlite3"
+  gem "sqlite3", "~> 1.3", "< 1.4"
 end
 
 platforms :jruby do

--- a/lib/closure_tree.rb
+++ b/lib/closure_tree.rb
@@ -1,4 +1,5 @@
 require 'active_record'
+require 'active_support/core_ext/string/strip'
 
 module ClosureTree
   extend ActiveSupport::Autoload


### PR DESCRIPTION
This is needed for Rails 6+ as this core_ext is no longer indirectly loaded.
It would be nice to use
```
<<~HEREDOC
    this will lose indentation
HEREDOC
```
introduced in Ruby 2.3 but this would break backwards compatibility.