### PR TITLE
Call Module#module_parent instead of deprecated #parent

### DIFF
--- a/lib/closure_tree/support.rb
+++ b/lib/closure_tree/support.rb
@@ -32,7 +32,8 @@ module ClosureTree
     end
 
     def hierarchy_class_for_model
-      hierarchy_class = model_class.parent.const_set(short_hierarchy_class_name, Class.new(ActiveRecord::Base))
+      parent_class = ActiveSupport::VERSION::MAJOR >= 6 ? model_class.module_parent : model_class.parent
+      hierarchy_class = parent_class.const_set(short_hierarchy_class_name, Class.new(ActiveRecord::Base))
       use_attr_accessible = use_attr_accessible?
       include_forbidden_attributes_protection = include_forbidden_attributes_protection?
       model_class_name = model_class.to_s


### PR DESCRIPTION
Solves Rails 6 deprecation warning.

Opening a duplicate PR as https://github.com/ClosureTree/closure_tree/pull/349 seems stale.

Fixes https://github.com/ClosureTree/closure_tree/issues/346.