### PR TITLE
Replace strip_heredoc with squish

### DIFF
--- a/lib/closure_tree.rb
+++ b/lib/closure_tree.rb
@@ -1,5 +1,4 @@
 require 'active_record'
-require 'active_support/core_ext/string/strip'
 
 module ClosureTree
   extend ActiveSupport::Autoload

--- a/lib/closure_tree/finders.rb
+++ b/lib/closure_tree/finders.rb
@@ -34,7 +34,7 @@ module ClosureTree
     end
 
     def find_all_by_generation(generation_level)
-      s = _ct.base_class.joins(<<-SQL.strip_heredoc)
+      s = _ct.base_class.joins(<<-SQL.squish)
         INNER JOIN (
           SELECT descendant_id
           FROM #{_ct.quoted_hierarchy_table_name}
@@ -70,7 +70,7 @@ module ClosureTree
       end
 
       def leaves
-        s = joins(<<-SQL.strip_heredoc)
+        s = joins(<<-SQL.squish)
           INNER JOIN (
             SELECT ancestor_id
             FROM #{_ct.quoted_hierarchy_table_name}
@@ -113,7 +113,7 @@ module ClosureTree
       end
 
       def find_all_by_generation(generation_level)
-        s = joins(<<-SQL.strip_heredoc)
+        s = joins(<<-SQL.squish)
           INNER JOIN (
             SELECT #{primary_key} as root_id
             FROM #{_ct.quoted_table_name}
@@ -143,7 +143,7 @@ module ClosureTree
         last_joined_table = _ct.table_name
         path.reverse.each_with_index do |ea, idx|
           next_joined_table = "p#{idx}"
-          scope = scope.joins(<<-SQL.strip_heredoc)
+          scope = scope.joins(<<-SQL.squish)
             INNER JOIN #{_ct.quoted_table_name} #{ _ct.t_alias_keyword } #{next_joined_table}
               ON #{next_joined_table}.#{_ct.quoted_id_column_name} =
  #{connection.quote_table_name(last_joined_table)}.#{_ct.quoted_parent_column_name}

--- a/lib/closure_tree/hash_tree_support.rb
+++ b/lib/closure_tree/hash_tree_support.rb
@@ -4,7 +4,7 @@ module ClosureTree
         # Deepest generation, within limit, for each descendant
         # NOTE: Postgres requires HAVING clauses to always contains aggregate functions (!!)
         having_clause = limit_depth ? "HAVING MAX(generations) <= #{limit_depth - 1}" : ''
-        generation_depth = <<-SQL.strip_heredoc
+        generation_depth = <<-SQL.squish
           INNER JOIN (
             SELECT descendant_id, MAX(generations) as depth
             FROM #{quoted_hierarchy_table_name}

--- a/lib/closure_tree/hierarchy_maintenance.rb
+++ b/lib/closure_tree/hierarchy_maintenance.rb
@@ -67,7 +67,7 @@ module ClosureTree
         delete_hierarchy_references unless (defined? @was_new_record) && @was_new_record
         hierarchy_class.create!(:ancestor => self, :descendant => self, :generations => 0)
         unless root?
-          _ct.connection.execute <<-SQL.strip_heredoc
+          _ct.connection.execute <<-SQL.squish
             INSERT INTO #{_ct.quoted_hierarchy_table_name}
               (ancestor_id, descendant_id, generations)
             SELECT x.ancestor_id, #{_ct.quote(_ct_id)}, x.generations + 1
@@ -94,7 +94,7 @@ module ClosureTree
         # It shouldn't affect performance of postgresql.
         # See http://dev.mysql.com/doc/refman/5.0/en/subquery-errors.html
         # Also: PostgreSQL doesn't support INNER JOIN on DELETE, so we can't use that.
-        _ct.connection.execute <<-SQL.strip_heredoc
+        _ct.connection.execute <<-SQL.squish
           DELETE FROM #{_ct.quoted_hierarchy_table_name}
           WHERE descendant_id IN (
             SELECT DISTINCT descendant_id

--- a/lib/closure_tree/numeric_deterministic_ordering.rb
+++ b/lib/closure_tree/numeric_deterministic_ordering.rb
@@ -51,7 +51,7 @@ module ClosureTree
 
       # If node is nil, order the whole tree.
       def _ct_sum_order_by(node = nil)
-        stats_sql = <<-SQL.strip_heredoc
+        stats_sql = <<-SQL.squish
           SELECT
             count(*) as total_descendants,
             max(generations) as max_depth
@@ -74,7 +74,7 @@ module ClosureTree
           raise ClosureTree::RootOrderingDisabledError.new("Root ordering is disabled on this model")
         end
 
-        join_sql = <<-SQL.strip_heredoc
+        join_sql = <<-SQL.squish
           JOIN #{_ct.quoted_hierarchy_table_name} anc_hier
             ON anc_hier.descendant_id = #{_ct.quoted_table_name}.#{_ct.quoted_id_column_name}
           JOIN #{_ct.quoted_table_name} anc

--- a/lib/closure_tree/numeric_order_support.rb
+++ b/lib/closure_tree/numeric_order_support.rb
@@ -21,7 +21,7 @@ module ClosureTree
           ""
         end
         connection.execute 'SET @i = 0'
-        connection.execute <<-SQL.strip_heredoc
+        connection.execute <<-SQL.squish
           UPDATE #{quoted_table_name}
             SET #{quoted_order_column} = (@i := @i + 1) + #{minimum_sort_order_value.to_i - 1}
           WHERE #{where_eq(parent_column_name, parent_id)} #{min_where}
@@ -38,7 +38,7 @@ module ClosureTree
         else
           ""
         end
-        connection.execute <<-SQL.strip_heredoc
+        connection.execute <<-SQL.squish
           UPDATE #{quoted_table_name}
           SET #{quoted_order_column(false)} = t.seq + #{minimum_sort_order_value.to_i - 1}
           FROM (


### PR DESCRIPTION
Switching to squish keeps log output on a single line.

Before:
```
Page Load (2.7ms)  SELECT "pages".* FROM "pages" INNER JOIN (
SELECT descendant_id, MAX(generations) as depth
FROM "page_hierarchies"
GROUP BY descendant_id

) AS generation_depth
ON "pages".id = generation_depth.descendant_id ORDER BY generation_depth.depth, position
```

After:
```
Page Load (1.9ms)  SELECT "pages".* FROM "pages" INNER JOIN ( SELECT descendant_id, MAX(generations) as depth FROM "page_hierarchies" GROUP BY descendant_id ) AS generation_depth ON "pages".id = generation_depth.descendant_id ORDER BY generation_depth.depth, position
```
