### PR TITLE
Use model_class as basis for hierarchy_class

### DIFF
--- a/lib/closure_tree/support.rb
+++ b/lib/closure_tree/support.rb
@@ -33,7 +33,7 @@ module ClosureTree
 
     def hierarchy_class_for_model
       parent_class = ActiveSupport::VERSION::MAJOR >= 6 ? model_class.module_parent : model_class.parent
-      hierarchy_class = parent_class.const_set(short_hierarchy_class_name, Class.new(ActiveRecord::Base))
+      hierarchy_class = parent_class.const_set(short_hierarchy_class_name, Class.new(model_class))
       use_attr_accessible = use_attr_accessible?
       include_forbidden_attributes_protection = include_forbidden_attributes_protection?
       model_class_name = model_class.to_s


### PR DESCRIPTION
It has long been possible for Active Record subclasses to use customized database connections, for example to connect to a different database.

More recently, Rails 6.0 added support for [multiple databases](https://guides.rubyonrails.org/active_record_multiple_databases.html). However, these features require model classes to inherit from `ApplicationRecord`. It is stated [here](https://github.com/rails/rails/pull/36394#issuecomment-499087859) that "each connection should have their own abstract class to deal with their connection."

This patch updates `ClosureTree::Support#hierarchy_class_for_model` to build the hierarchy class from the model class, which ensures they use the same connection.