### PR TITLE
Fix raw SQL argument deprecation warning

### DIFF
--- a/lib/closure_tree/support_attributes.rb
+++ b/lib/closure_tree/support_attributes.rb
@@ -80,7 +80,7 @@ module ClosureTree
     end
 
     def nulls_last_order_by
-      "-#{quoted_order_column} #{order_by_order(true)}"
+      Arel.sql "-#{quoted_order_column} #{order_by_order(true)}"
     end
 
     def order_by_order(reverse = false)


### PR DESCRIPTION
Hi!

This PR is only wrapping with Arel.sql a raw SQL argument passed when deterministic ordering is set. 

Rails 6 is showing a deprecation warning and it seem will be already broken by version 6.1

`DEPRECATION WARNING: Dangerous query method (method whose arguments are used as raw SQL) called with non-attribute argument(s): "-\"MODEL\".\"sort_order\" DESC". Non-attribute arguments will be disallowed in Rails 6.1. This method should not be called with user-provided values, such as request parameters or model attributes. Known-safe values can be passed by wrapping them in Arel.sql().
`