### PR TITLE
Add an option `database_type`

### DIFF
--- a/lib/closure_tree/has_closure_tree.rb
+++ b/lib/closure_tree/has_closure_tree.rb
@@ -11,7 +11,8 @@ module ClosureTree
         :dont_order_roots,
         :numeric_order,
         :touch,
-        :with_advisory_lock
+        :with_advisory_lock,
+        :database_type
       )
 
       class_attribute :_ct

--- a/lib/closure_tree/numeric_order_support.rb
+++ b/lib/closure_tree/numeric_order_support.rb
@@ -12,6 +12,17 @@ module ClosureTree
       end
     end
 
+    def self.adapter_for_database_type(database_type)
+      case database_type
+      when :postgres
+        ::ClosureTree::NumericOrderSupport::PostgreSQLAdapter
+      when :mysql
+        ::ClosureTree::NumericOrderSupport::MysqlAdapter
+      else
+        ::ClosureTree::NumericOrderSupport::GenericAdapter
+      end
+    end
+
     module MysqlAdapter
       def reorder_with_parent_id(parent_id, minimum_sort_order_value = nil)
         return if parent_id.nil? && dont_order_roots

--- a/lib/closure_tree/support_flags.rb
+++ b/lib/closure_tree/support_flags.rb
@@ -31,5 +31,9 @@ module ClosureTree
     def has_name?
       model_class.new.attributes.include? options[:name_column]
     end
+
+    def database_type_from_options
+      options[:database_type]
+    end
   end
 end


### PR DESCRIPTION
Problem: When using `numeric_ordering: true`, closure_tree tries to find out the type of database during the initialization process. This can be problematic, for example when doing `rails db:create`, in which case there is no database, yet. Another scenario is `rails asssets:prcompile` in a Docker container that is being made for production, but it doesn't have access to the production database yet, because it isn't rolled out, yet.

Solution: I have added an option to specify the database_type manually. This option is *only* used then numeric_ordering is set to `true`