### PR TITLE
add :child_order to .rebuild!

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,8 @@ end
 ```
 This way, the complete hierarchy including all subclasses will be rebuilt.
 
+If you need to preserve a certain children order to rebuild your tree you can call `rebuild` with the keyword `child_order` and give a regular ordering hash: `rebuild!(child_order: {name: :desc})`
+
 ## Deterministic ordering
 
 By default, children will be ordered by your database engine, which may not be what you want.

--- a/spec/closure_tree/hierarchy_maintenance_spec.rb
+++ b/spec/closure_tree/hierarchy_maintenance_spec.rb
@@ -12,6 +12,15 @@ RSpec.describe ClosureTree::HierarchyMaintenance do
       Metal.rebuild!
       expect(MetalHierarchy.count).to eq(hierarchy_count)
     end
+
+    it 'rebuild tree with specific child order' do
+      parent = Metal.create(value: "Parent")
+      Metal.create(value: "name3")
+      Metal.create(value: "name1")
+      Metal.create(value: "name2")
+      expect(parent.children).to receive(:reorder).with({value: :desc}).once.and_call_original
+      parent.rebuild!(child_order: {value: :desc})
+    end
   end
 
   describe '.cleanup!' do


### PR DESCRIPTION
https://github.com/ClosureTree/closure_tree/issues/376

in order to respect a certain children order when calling rebuild! the children will be reordered with whatever the argument of `child_order` was

