### PR TITLE
fix: hierarchy model with namespace should inherit from the superclass of basic model

### DIFF
--- a/lib/closure_tree/support.rb
+++ b/lib/closure_tree/support.rb
@@ -33,14 +33,11 @@ module ClosureTree
 
     def hierarchy_class_for_model
       parent_class = ActiveSupport::VERSION::MAJOR >= 6 ? model_class.module_parent : model_class.parent
-      temp_database_config = model_class.connection_config
-      model_class_database_config = temp_database_config.clone
-      hierarchy_class = parent_class.const_set(short_hierarchy_class_name, Class.new(ActiveRecord::Base))
+      hierarchy_class = parent_class.const_set(short_hierarchy_class_name, Class.new(model_class.superclass))
       use_attr_accessible = use_attr_accessible?
       include_forbidden_attributes_protection = include_forbidden_attributes_protection?
       model_class_name = model_class.to_s
       hierarchy_class.class_eval do
-        establish_connection model_class_database_config
         include ActiveModel::ForbiddenAttributesProtection if include_forbidden_attributes_protection
         belongs_to :ancestor, class_name: model_class_name
         belongs_to :descendant, class_name: model_class_name

--- a/lib/closure_tree/support.rb
+++ b/lib/closure_tree/support.rb
@@ -33,7 +33,9 @@ module ClosureTree
 
     def hierarchy_class_for_model
       parent_class = ActiveSupport::VERSION::MAJOR >= 6 ? model_class.module_parent : model_class.parent
-      hierarchy_class = parent_class.const_set(short_hierarchy_class_name, Class.new(ActiveRecord::Base))
+      temp_target_class = ActiveSupport::VERSION::MAJOR >= 5 ? ApplicationRecord : ActiveRecord::Base
+      target_class = parent_class.const_get(temp_target_class.to_s)
+      hierarchy_class = parent_class.const_set(short_hierarchy_class_name, Class.new(target_class))
       use_attr_accessible = use_attr_accessible?
       include_forbidden_attributes_protection = include_forbidden_attributes_protection?
       model_class_name = model_class.to_s

--- a/lib/closure_tree/support.rb
+++ b/lib/closure_tree/support.rb
@@ -33,13 +33,14 @@ module ClosureTree
 
     def hierarchy_class_for_model
       parent_class = ActiveSupport::VERSION::MAJOR >= 6 ? model_class.module_parent : model_class.parent
-      temp_target_class = ActiveSupport::VERSION::MAJOR >= 5 ? ApplicationRecord : ActiveRecord::Base
-      target_class = parent_class.const_get(temp_target_class.to_s)
-      hierarchy_class = parent_class.const_set(short_hierarchy_class_name, Class.new(target_class))
+      temp_database_config = model_class.connection_config
+      model_class_database_config = temp_database_config.clone
+      hierarchy_class = parent_class.const_set(short_hierarchy_class_name, Class.new(ActiveRecord::Base))
       use_attr_accessible = use_attr_accessible?
       include_forbidden_attributes_protection = include_forbidden_attributes_protection?
       model_class_name = model_class.to_s
       hierarchy_class.class_eval do
+        establish_connection model_class_database_config
         include ActiveModel::ForbiddenAttributesProtection if include_forbidden_attributes_protection
         belongs_to :ancestor, class_name: model_class_name
         belongs_to :descendant, class_name: model_class_name


### PR DESCRIPTION
#382 
FYI: In my case, I have a namespace AAA for billing, and billing model inherits from AAA::ApplicationRecord. 
Like the following code:
```
module AAA
  class Billing < ApplicationRecord
    connects_to database: { writing: :foo_service, reading: :foo_service}
    has_closure_tree
  end
end

module AAA
  class ApplicationRecord < ActiveRecord::Base
    connects_to database: { writing: :aaa, reading: :aaa }

    self.abstract_class = true
  end
end
```
Therefore if I follow the unmodified code to execute, AAA::BillingHierarchy will inherit from ApplicationRecord, not AAA::ApplicationRecord, then it will connect to primary database, not aaa database. 


PTAL.Thank you.