### PR TITLE
Initial counter_cache implementation

### DIFF
--- a/lib/closure_tree/has_closure_tree.rb
+++ b/lib/closure_tree/has_closure_tree.rb
@@ -11,7 +11,8 @@ module ClosureTree
         :dont_order_roots,
         :numeric_order,
         :touch,
-        :with_advisory_lock
+        :with_advisory_lock,
+        :counter_cache
       )
 
       class_attribute :_ct

--- a/lib/closure_tree/model.rb
+++ b/lib/closure_tree/model.rb
@@ -11,7 +11,9 @@ module ClosureTree
         foreign_key: _ct.parent_column_name,
         inverse_of: :children,
         touch: _ct.options[:touch],
-        optional: true)
+        optional: true,
+        counter_cache: _ct.options[:counter_cache],
+      )
 
       order_by_generations = -> { Arel.sql("#{_ct.quoted_hierarchy_table_name}.generations ASC") }
 

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -15,7 +15,7 @@ end
 class UUIDTag < ActiveRecord::Base
   self.primary_key = :uuid
   before_create :set_uuid
-  has_closure_tree dependent: :destroy, order: 'name', parent_column_name: 'parent_uuid'
+  has_closure_tree dependent: :destroy, order: 'name', parent_column_name: 'parent_uuid', counter_cache: true
   before_destroy :add_destroyed_tag
 
   def set_uuid

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -27,6 +27,7 @@ ActiveRecord::Schema.define(:version => 0) do
     t.string "title"
     t.string "parent_uuid"
     t.integer "sort_order"
+    t.integer "uuid_tags_count", default: 0, null: false
     t.timestamps null: false
   end
 

--- a/spec/support/tag_examples.rb
+++ b/spec/support/tag_examples.rb
@@ -23,6 +23,11 @@ RSpec.shared_examples_for Tag do
       expected_parent_column_name = tag_class == UUIDTag ? 'parent_uuid' : 'parent_id'
       expect(tag_class._ct.parent_column_name).to eq(expected_parent_column_name)
     end
+
+    it 'should counter_cache parent relationship' do
+      expected_counter_cache = tag_class == UUIDTag ? true : nil
+      expect(tag_class._ct.options[:counter_cache]).to be expected_counter_cache
+    end
   end
 
   describe 'from empty db' do


### PR DESCRIPTION
This implements a `counter_cache` option, which is passed to the `parent` relationship. This allows closure tree structures to use `tag.tags_count` rather than `tag.children.count`. This is much faster for large data sets, where counts are prohibitively slow.

### TODO

- [ ] Write documentation for the feature