### PR TITLE
Reference ancestor_hierarchies in depth instead of ancestors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 8.0.0
 
 - Drop support to EOL ruby and rails
+- Reference ancestor_hierarchies in depth instead of ancestors to avoid n+1
 
 ## [7.4.0](https://github.com/ClosureTree/closure_tree/tree/7.4.0)
 

--- a/lib/closure_tree/model.rb
+++ b/lib/closure_tree/model.rb
@@ -77,7 +77,7 @@ module ClosureTree
     end
 
     def depth
-      ancestors.size
+      ancestor_hierarchies.size
     end
 
     alias_method :level, :depth


### PR DESCRIPTION
This is helpful because we can more easily eager load ancestor_hierarchies than we can ancestors to avoid n + 1 queries.

```ruby
tag = Tag.includes(:ancestor_hierarchies).first
tag.depth
```