### PR TITLE
Fix compound unique index for hierarchies_table

### DIFF
--- a/lib/generators/closure_tree/templates/create_hierarchies_table.rb.erb
+++ b/lib/generators/closure_tree/templates/create_hierarchies_table.rb.erb
@@ -6,9 +6,12 @@ class <%= migration_class_name %> < ActiveRecord::Migration<%= migration_version
       t.integer :generations, null: false
     end
 
-    add_index :<%= migration_name %>, [:ancestor_id, :descendant_id, :generations],
+    add_index :<%= migration_name %>, [:ancestor_id, :descendant_id],
       unique: true,
-      name: "<%= file_name %>_anc_desc_idx"
+      name: "<%= file_name %>_anc_desc_uniq_idx"
+
+    add_index :<%= migration_name %>, [:ancestor_id, :descendant_id, :generations],
+      name: "<%= file_name %>_anc_desc_gene_idx"
 
     add_index :<%= migration_name -%>, [:descendant_id],
       name: "<%= file_name %>_desc_idx"

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -34,8 +34,11 @@ ActiveRecord::Schema.define(version: 0) do
     t.string 'name'
   end
 
-  add_index 'tag_hierarchies', %i[ancestor_id descendant_id generations], unique: true,
-                                                                          name: 'tag_anc_desc_idx'
+  add_index 'tag_hierarchies', %i[ancestor_id descendant_id], unique: true,
+                                                              name: 'tag_anc_desc_uniq_idx'
+
+  add_index 'tag_hierarchies', %i[ancestor_id descendant_id generations], name: 'tag_anc_desc_gene_idx'
+
   add_index 'tag_hierarchies', [:descendant_id], name: 'tag_desc_idx'
 
   create_table 'groups', force: true do |t|


### PR DESCRIPTION
issue: https://github.com/ClosureTree/closure_tree/issues/410
I feel that the unique compound index of `ancestor_id` and `descendant_id`, is needed and `generations` is redundant.
Because there should be only one kind of `generations` for a set of `ancestor_id` and `descendant_id`.

The current table definition allows for the creation of multiple depth parent-child relationships.

## example
![item_hierarchies](https://user-images.githubusercontent.com/1322208/215313114-d9b729bf-7b52-4307-8e33-d9235bad26cf.png)


### items
id | content | parent_id
| -- | -- | -- |
1|"Parent"|NULL
2|"First Child"|1
3|"Second Child"|1
4|"First Grandchild"|3


### item_hierarchies
| ancestor_id | descendant_id | generations |
| -- | -- | -- |
1|1|0
1|2|1
2|2|0
1|3|1
3|3|0
1|4|2
3|4|1
4|4|0

I could also add this record.
```sql
INSERT INTO `item_hierarchies` (`ancestor_id`, `descendant_id`, `generations`) VALUES (1, 4, 1);
```


However, If there is a search by `ancestor_id`, `descendant_id` and `generations` columns, considering performance point of view, the disappearance of the `ancestor_id`, `descendant_id` and `generations` composite indexes is not good.
Therefore, I think it needs to be redefined.