### PR TITLE
Test fixes

### DIFF
--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 ActiveRecord::Schema.define(version: 0) do
-  create_table 'tags', force: true do |t|
+  create_table 'tags', force: :cascade do |t|
     t.string 'name'
     t.string 'title'
     t.references 'parent'
@@ -9,13 +9,13 @@ ActiveRecord::Schema.define(version: 0) do
     t.timestamps null: false
   end
 
-  create_table 'tag_hierarchies', id: false, force: true do |t|
+  create_table 'tag_hierarchies', id: false, force: :cascade do |t|
     t.references 'ancestor', null: false
     t.references 'descendant', null: false
     t.integer 'generations', null: false
   end
 
-  create_table 'uuid_tags', id: false, force: true do |t|
+  create_table 'uuid_tags', id: false, force: :cascade do |t|
     t.string 'uuid', unique: true
     t.string 'name'
     t.string 'title'
@@ -24,13 +24,13 @@ ActiveRecord::Schema.define(version: 0) do
     t.timestamps null: false
   end
 
-  create_table 'uuid_tag_hierarchies', id: false, force: true do |t|
+  create_table 'uuid_tag_hierarchies', id: false, force: :cascade do |t|
     t.string 'ancestor_id', null: false
     t.string 'descendant_id', null: false
     t.integer 'generations', null: false
   end
 
-  create_table 'destroyed_tags', force: true do |t|
+  create_table 'destroyed_tags', force: :cascade do |t|
     t.string 'name'
   end
 
@@ -38,81 +38,81 @@ ActiveRecord::Schema.define(version: 0) do
                                                                           name: 'tag_anc_desc_idx'
   add_index 'tag_hierarchies', [:descendant_id], name: 'tag_desc_idx'
 
-  create_table 'groups', force: true do |t|
+  create_table 'groups', force: :cascade do |t|
     t.string 'name', null: false
   end
 
-  create_table 'groupings', force: true do |t|
+  create_table 'groupings', force: :cascade do |t|
     t.string 'name', null: false
   end
 
-  create_table 'user_sets', force: true do |t|
+  create_table 'user_sets', force: :cascade do |t|
     t.string 'name', null: false
   end
 
-  create_table 'teams', force: true do |t|
+  create_table 'teams', force: :cascade do |t|
     t.string 'name', null: false
   end
 
-  create_table 'users', force: true do |t|
+  create_table 'users', force: :cascade do |t|
     t.string 'email'
     t.references 'referrer'
     t.integer 'group_id'
     t.timestamps null: false
   end
 
-  create_table 'contracts', force: true do |t|
+  create_table 'contracts', force: :cascade do |t|
     t.references 'user', null: false
     t.references 'contract_type'
     t.string 'title'
   end
 
-  create_table 'contract_types', force: true do |t|
+  create_table 'contract_types', force: :cascade do |t|
     t.string 'name', null: false
   end
 
-  create_table 'referral_hierarchies', id: false, force: true do |t|
+  create_table 'referral_hierarchies', id: false, force: :cascade do |t|
     t.references 'ancestor', null: false
     t.references 'descendant', null: false
     t.integer 'generations', null: false
   end
 
-  create_table 'labels', force: true do |t|
+  create_table 'labels', force: :cascade do |t|
     t.string 'name'
     t.string 'type'
     t.integer 'column_whereby_ordering_is_inferred'
     t.references 'mother'
   end
 
-  create_table 'label_hierarchies', id: false do |t|
+  create_table 'label_hierarchies', id: false, force: :cascade do |t|
     t.references 'ancestor', null: false
     t.references 'descendant', null: false
     t.integer 'generations', null: false
   end
 
-  create_table 'cuisine_types', force: true do |t|
+  create_table 'cuisine_types', force: :cascade do |t|
     t.string 'name'
     t.references 'parent'
   end
 
-  create_table 'cuisine_type_hierarchies', id: false, force: true do |t|
+  create_table 'cuisine_type_hierarchies', id: false, force: :cascade do |t|
     t.references 'ancestor', null: false
     t.references 'descendant', null: false
     t.integer 'generations', null: false
   end
 
-  create_table 'namespace_types', force: true do |t|
+  create_table 'namespace_types', force: :cascade do |t|
     t.string 'name'
     t.references 'parent'
   end
 
-  create_table 'namespace_type_hierarchies', id: false, force: true do |t|
+  create_table 'namespace_type_hierarchies', id: false, force: :cascade do |t|
     t.references 'ancestor', null: false
     t.references 'descendant', null: false
     t.integer 'generations', null: false
   end
 
-  create_table 'metal', force: true do |t|
+  create_table 'metal', force: :cascade do |t|
     t.references 'parent'
     t.string 'metal_type'
     t.string 'value'
@@ -120,19 +120,19 @@ ActiveRecord::Schema.define(version: 0) do
     t.integer 'sort_order'
   end
 
-  create_table 'metal_hierarchies', id: false, force: true do |t|
+  create_table 'metal_hierarchies', id: false, force: :cascade do |t|
     t.references 'ancestor', null: false
     t.references 'descendant', null: false
     t.integer 'generations', null: false
   end
 
-  create_table 'menu_items', force: true do |t|
+  create_table 'menu_items', force: :cascade do |t|
     t.string 'name'
     t.references 'parent'
     t.timestamps null: false
   end
 
-  create_table 'menu_item_hierarchies', id: false, force: true do |t|
+  create_table 'menu_item_hierarchies', id: false, force: :cascade do |t|
     t.references 'ancestor', null: false
     t.references 'descendant', null: false
     t.integer 'generations', null: false

--- a/test/closure_tree/tag_test.rb
+++ b/test/closure_tree/tag_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'test_helper'
+require 'support/tag_examples'
 
 describe Tag do
   include TagExamples

--- a/test/closure_tree/uuid_tag_test.rb
+++ b/test/closure_tree/uuid_tag_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'test_helper'
+require 'support/tag_examples'
 
 describe UUIDTag do
   include TagExamples

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -45,7 +45,7 @@ puts "Testing with #{env_db} database, ActiveRecord #{ActiveRecord.gem_version} 
 
 DatabaseCleaner.strategy = :transaction
 
-module MiniTest
+module Minitest
   class Spec
     include QueryCounter
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -67,4 +67,3 @@ Thread.abort_on_exception = true
 require 'closure_tree'
 require_relative '../spec/support/schema'
 require_relative '../spec/support/models'
-require 'support/tag_examples'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -43,7 +43,7 @@ end
 ActiveRecord::Base.connection.recreate_database('closure_tree_test') unless sqlite?
 puts "Testing with #{env_db} database, ActiveRecord #{ActiveRecord.gem_version} and #{RUBY_ENGINE} #{RUBY_ENGINE_VERSION} as #{RUBY_VERSION}"
 
-DatabaseCleaner.strategy = :transaction
+DatabaseCleaner.strategy = :truncation
 
 module Minitest
   class Spec


### PR DESCRIPTION
While trying to run the tests locally, I had to make a few changes to make things work:

- `MiniTest` has apparently been renamed to `Minitest` at some point (this apparently also broke the most recent [CI runs](https://github.com/ClosureTree/closure_tree/actions/runs/6684636015/job/18162114666))
- Schema files have to use `force: :cascade` so the recreation of the schema does not fail because of dependencies (at least on PostgreSQL)
- the `tag_examples` module was evaluated as actual tests while trying to run any different test file, leading to hundreds of errors. Just requiring it where it's needed seems to help with that.

Now I am at the point where all tests except the parallel_test are running fine, but that's a separate topic :)