### PR TITLE
fix sqlite3 version

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -5,7 +5,7 @@ appraise 'activerecord-6.1' do
   platforms :ruby do
     gem 'mysql2'
     gem 'pg'
-    gem 'sqlite3'
+    gem 'sqlite3', '< 2.0'
   end
 
   platforms :jruby do
@@ -20,7 +20,7 @@ appraise 'activerecord-7.0' do
   platforms :ruby do
     gem 'mysql2'
     gem 'pg'
-    gem 'sqlite3'
+    gem 'sqlite3', '< 2.0'
   end
 
   platforms :jruby do
@@ -35,7 +35,7 @@ appraise 'activerecord-7.1' do
   platforms :ruby do
     gem 'mysql2'
     gem 'pg'
-    gem 'sqlite3'
+    gem 'sqlite3', '< 2.0'
   end
 
   platforms :jruby do

--- a/gemfiles/activerecord_6.1.gemfile
+++ b/gemfiles/activerecord_6.1.gemfile
@@ -14,7 +14,7 @@ end
 platforms :ruby do
   gem "mysql2"
   gem "pg"
-  gem "sqlite3"
+  gem "sqlite3", "< 2.0"
 end
 
 platforms :jruby do

--- a/gemfiles/activerecord_7.0.gemfile
+++ b/gemfiles/activerecord_7.0.gemfile
@@ -14,7 +14,7 @@ end
 platforms :ruby do
   gem "mysql2"
   gem "pg"
-  gem "sqlite3"
+  gem "sqlite3", "< 2.0"
 end
 
 platforms :jruby do

--- a/gemfiles/activerecord_7.1.gemfile
+++ b/gemfiles/activerecord_7.1.gemfile
@@ -14,7 +14,7 @@ end
 platforms :ruby do
   gem "mysql2"
   gem "pg"
-  gem "sqlite3"
+  gem "sqlite3", "< 2.0"
 end
 
 platforms :jruby do


### PR DESCRIPTION
While execute spec with appraisal, I caught error.


```
An error occurred while loading ./spec/closure_tree/matcher_spec.rb. - Did you mean?
                    rspec ./spec/closure_tree/has_closure_tree_root_spec.rb

Failure/Error: ActiveRecord::Base.establish_connection

LoadError:
  Error loading the 'sqlite3' Active Record adapter. Missing a gem it depends on? can't activate sqlite3 (~> 1.4), already activated sqlite3-2.0.2-arm64-darwin. Make sure all dependencies are added to Gemfile.
# ./spec/spec_helper.rb:34:in `<top (required)>'
# ./spec/closure_tree/matcher_spec.rb:1:in `<top (required)>'
# ------------------
# --- Caused by: ---
# Gem::LoadError:
#   can't activate sqlite3 (~> 1.4), already activated sqlite3-2.0.2-arm64-darwin. Make sure all dependencies are added to Gemfile.
#   ./spec/spec_helper.rb:34:in `<top (required)>'
```
sqlite3 v2 is supported by only rails 7.2 or above

ref: https://github.com/rails/rails/commit/fd1c635d2f1