### PR TITLE
Fix the uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger error

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-
+require 'logger'
 require 'database_cleaner'
 require 'closure_tree/test/matcher'
 require 'tmpdir'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'logger'
 require 'erb'
 require 'active_record'
 require 'with_advisory_lock'


### PR DESCRIPTION
The `concurrent-ruby` gem stopped depending on Logger. It should be now required manually.
