### PR TITLE
feat: use new with_advisory_lock

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,5 @@
 source 'https://rubygems.org'
 
 gemspec
+
+gem 'with_advisory_lock', github: 'closuretree/with_advisory_lock'

--- a/closure_tree.gemspec
+++ b/closure_tree.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 3.3.0'
 
   gem.add_runtime_dependency 'activerecord', '>= 7.1.0'
-  gem.add_runtime_dependency 'with_advisory_lock', '>= 5.0.0', '< 6.0.0'
+  gem.add_runtime_dependency 'with_advisory_lock', '>= 6.0.0'
 
   gem.add_development_dependency 'appraisal'
   gem.add_development_dependency 'database_cleaner'

--- a/gemfiles/activerecord_7.1.gemfile
+++ b/gemfiles/activerecord_7.1.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "with_advisory_lock", github: "closuretree/with_advisory_lock"
 gem "activerecord", "~> 7.1.0"
 gem "railties"
 

--- a/gemfiles/activerecord_7.2.gemfile
+++ b/gemfiles/activerecord_7.2.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "with_advisory_lock", github: "closuretree/with_advisory_lock"
 gem "activerecord", "~> 7.2.0"
 gem "railties"
 

--- a/gemfiles/activerecord_8.0.gemfile
+++ b/gemfiles/activerecord_8.0.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "with_advisory_lock", github: "closuretree/with_advisory_lock"
 gem "activerecord", "~> 8.0.0"
 gem "railties"
 

--- a/gemfiles/activerecord_edge.gemfile
+++ b/gemfiles/activerecord_edge.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "with_advisory_lock", github: "closuretree/with_advisory_lock"
 gem "activerecord", github: "rails/rails"
 gem "railties", github: "rails/rails"
 

--- a/lib/closure_tree/numeric_order_support.rb
+++ b/lib/closure_tree/numeric_order_support.rb
@@ -2,10 +2,10 @@ module ClosureTree
   module NumericOrderSupport
 
     def self.adapter_for_connection(connection)
-      das = WithAdvisoryLock::DatabaseAdapterSupport.new(connection)
-      if das.postgresql?
+      adapter_name = connection.adapter_name.downcase
+      if adapter_name.include?('postgresql') || adapter_name.include?('postgis')
         ::ClosureTree::NumericOrderSupport::PostgreSQLAdapter
-      elsif das.mysql?
+      elsif adapter_name.include?('mysql') || adapter_name.include?('trilogy')
         ::ClosureTree::NumericOrderSupport::MysqlAdapter
       else
         ::ClosureTree::NumericOrderSupport::GenericAdapter

--- a/lib/closure_tree/support_flags.rb
+++ b/lib/closure_tree/support_flags.rb
@@ -1,16 +1,6 @@
 module ClosureTree
   module SupportFlags
 
-    def use_attr_accessible?
-      defined?(ActiveModel::MassAssignmentSecurity) &&
-        model_class.respond_to?(:accessible_attributes) &&
-        ! model_class.accessible_attributes.empty?
-    end
-
-    def include_forbidden_attributes_protection?
-      defined?(ActiveModel::ForbiddenAttributesProtection) &&
-        model_class.ancestors.include?(ActiveModel::ForbiddenAttributesProtection)
-    end
 
     def order_option?
       order_by.present?

--- a/test/closure_tree/matcher_test.rb
+++ b/test/closure_tree/matcher_test.rb
@@ -28,9 +28,14 @@ class MatcherTest < ActiveSupport::TestCase
   end
 
   test "advisory_lock option" do
-    assert_closure_tree User, with_advisory_lock: true
-    assert_closure_tree Label, ordered: true, with_advisory_lock: true
-    assert_closure_tree Metal, ordered: :sort_order, with_advisory_lock: true
+    # SQLite doesn't support advisory locks, so skip these tests when using SQLite
+    if ActiveRecord::Base.connection.adapter_name.downcase.include?('sqlite')
+      skip "SQLite doesn't support advisory locks"
+    else
+      assert_closure_tree User, with_advisory_lock: true
+      assert_closure_tree Label, ordered: true, with_advisory_lock: true
+      assert_closure_tree Metal, ordered: :sort_order, with_advisory_lock: true
+    end
   end
 
   test "without_advisory_lock option" do

--- a/test/support/tag_examples.rb
+++ b/test/support/tag_examples.rb
@@ -12,11 +12,6 @@ module TagExamples
     end
 
     describe 'class setup' do
-      it 'has correct accessible_attributes' do
-        if @tag_class._ct.use_attr_accessible?
-          assert_equal(%w[parent name title].sort, @tag_class.accessible_attributes.to_a.sort)
-        end
-      end
 
       it 'should build hierarchy classname correctly' do
         assert_equal @tag_hierarchy_class, @tag_class.hierarchy_class


### PR DESCRIPTION
    - Removed deprecated Rails 3/4 features
    - Removed use_attr_accessible? and include_forbidden_attributes_protection? methods.
    - Removed attr_accessible declarations.
    - Fixed SQLite compatibility.
    - Auto-disabled advisory locks for SQLite (since it doesn't support them) 
    - SQLite will be supported if it behave, if causing maintenance burden, we  will remove.

This commit is transitional , further refactoring are required.
