### PR TITLE
Fix ambiguous ORDER BY clauses by fully qualifying column names

### DIFF
--- a/lib/closure_tree/numeric_order_support.rb
+++ b/lib/closure_tree/numeric_order_support.rb
@@ -42,7 +42,7 @@ module ClosureTree
           UPDATE #{quoted_table_name}
           SET #{quoted_order_column(false)} = t.seq + #{minimum_sort_order_value.to_i - 1}
           FROM (
-            SELECT #{quoted_id_column_name} AS id, row_number() OVER(ORDER BY #{order_by}) AS seq
+            SELECT #{quoted_id_column_name} AS id, row_number() OVER(ORDER BY #{fully_qualified_order_by}) AS seq
             FROM #{quoted_table_name}
             WHERE #{where_eq(parent_column_name, parent_id)} #{min_where}
           ) AS t

--- a/lib/closure_tree/support.rb
+++ b/lib/closure_tree/support.rb
@@ -66,14 +66,14 @@ module ClosureTree
 
     def with_order_option(opts)
       if order_option?
-        opts[:order] = [opts[:order], order_by].compact.join(",")
+        opts[:order] = [opts[:order], fully_qualified_order_by].compact.join(",")
       end
       opts
     end
 
     def scope_with_order(scope, additional_order_by = nil)
       if order_option?
-        scope.order(*([additional_order_by, order_by].compact))
+        scope.order(*([additional_order_by, fully_qualified_order_by].compact))
       else
         additional_order_by ? scope.order(additional_order_by) : scope
       end
@@ -85,7 +85,7 @@ module ClosureTree
     end
 
     def has_many_order_with_option(order_by_opt=nil)
-      order_options = [order_by_opt, order_by].compact
+      order_options = [order_by_opt, fully_qualified_order_by].compact
       [lambda {
         order_options = order_options.map { |o| o.is_a?(Proc) ? o.call : o }
         order(order_options)

--- a/lib/closure_tree/support_attributes.rb
+++ b/lib/closure_tree/support_attributes.rb
@@ -115,6 +115,10 @@ module ClosureTree
       "#{prefix}#{connection.quote_column_name(order_column)}"
     end
 
+    def fully_qualified_order_by
+      "#{quoted_order_column} #{order_by_order}"
+    end
+
     # table_name alias keyword , like "AS". When used on table name alias, Oracle Database don't support used 'AS'
     def t_alias_keyword
       (ActiveRecord::Base.connection.adapter_name.to_sym == :OracleEnhanced) ? "" : "AS"


### PR DESCRIPTION
This pull request addresses potential SQL ambiguity issues in ORDER BY clauses by introducing and using a new method: fully_qualified_order_by.

## Changes made:
- Introduced fully_qualified_order_by, which combines the quoted table and column name with sort direction.

- Replaced ambiguous `order_by` references with `fully_qualified_order_by` in:
   - `reorder_with_parent_id` (in `numeric_order_support.rb`)
   - `with_order_option`,  `scope_with_order`, and `has_many_order_with_option` (in `support.rb`)
   
## Why?
tldr: If you try to use joins or subqueries in a relationship and you have a positional column with the same name the closure tree uses you are going to have, see and feel pain inflicted upon you.
This PR aims to fix this. 

Suppose you have two closure trees for different things and they share a relationship;
```ruby
class InternalCategory < ApplicationRecord
  has_closure_tree order: "position"
end

class ExternalCategory < ApplicationRecord
  has_closure_tree order: "position"
  has_many :internal_category_classifications
  has_many :internal_categories, through: :internal_category_classifications
  
  has_many :descendants_internal_category, through: :self_and_descendants, source: :internal_categories
  
  has_many :bar_external_categories
end

class Bar < ApplicationRecord
  has_many :bar_external_categories,
  has_many :external_categories
end

class Foo < ApplicationRecord
  belongs_to :bar
  has_many :external_categories, through: :bar
end

class Biz < ApplicationRecord
  belongs_to :foo
  belongs_to :internal_category # always a root category
  
  has_many :external_categories,
                     lambda { |biz|
                       joins(:internal_categories)
                         .joins("inner join internal_category_hierarchies on internal_categories.id = internal_category_hierarchies.descendant_id")
                         .where("internal_category_hierarchies.ancestor_id = #{biz.internal_category_id}")
                     },
                     through: :foo,
                     source:    :external_categories
end
```

`Biz#external_categories` will trip up a `"PG::AmbiguousColumn: ERROR:  column reference "position" is ambiguous"` on postgresql

The real world use case is a lot more convoluted than this, but I think I simplified it enough to be understandable to why the order expression should be fully qualified with table name and column name