### PR TITLE
fix: configure release-please to recognize v8.0.0 release

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,4 +1,15 @@
 {
   "release-type": "ruby",
-  "package-name": "closure_tree"
+  "package-name": "closure_tree",
+  "packages": {
+    ".": {
+      "release-type": "ruby",
+      "package-name": "closure_tree",
+      "changelog-path": "CHANGELOG.md",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "versioning": "default"
+    }
+  },
+  "bootstrap-sha": "422f61687e779d9888304eeacb2c7ce72125eb64"
 }


### PR DESCRIPTION
This PR updates the release-please configuration to properly recognize the v8.0.0 release and enable it to create release PRs for subsequent commits.

## Changes
- Add bootstrap-sha pointing to the v8.0.0 release commit
- Add detailed package configuration for better release management

## Why is this needed?
Release-please wasn't creating PRs because it didn't recognize the manually created v8.0.0 release. This configuration tells release-please where to start looking for new commits.

After this is merged, release-please should create a PR for version 8.1.0 including:
- feat: rewrite with clean api (#451)
- refactor: convert SQL queries to Arel where feasible (#453)
- feat: Add runtime advisory lock name customization and multi-database documentation (#454)