### PR TITLE
Document `alias level depth` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ When you include ```has_closure_tree``` in your model, you can provide a hash to
 * ```tag.child?``` returns true if this is a child node. It has a parent.
 * ```tag.leaf?``` returns true if this is a leaf node. It has no children.
 * ```tag.leaves``` is scoped to all leaf nodes in self_and_descendants.
-* ```tag.depth``` returns the depth, or "generation", for this node in the tree. A root node will have a value of 0.
+* ```tag.depth``` returns the depth, or "generation", for this node in the tree. A root node will have a value of 0. Also aliased as `level`.
 * ```tag.parent``` returns the node's immediate parent. Root nodes will return nil.
 * ```tag.parent_of?(node)``` returns true if current node is parent of another one
 * ```tag.children``` is a ```has_many``` of immediate children (just those nodes whose parent is the current node).


### PR DESCRIPTION
I had weird issues caused by an enum defined on my model that conflicted with closure_tree. I had a hard time understanding this because [this alias](https://github.com/ClosureTree/closure_tree/blob/99e295a97611759d379c457282336635497d5f4d/lib/closure_tree/model.rb#L44) was not documented in the README.

```rb
class TaxonomyNode < ApplicationRecord
  enum :level, { family: 0, subfamily: 1, tribe: 2, genus: 3, subgenus: 4 }, validate: true

  has_closure_tree
end
```

This PR adds an mention in the README.

It would also be a good idea to provide a list of potentially conflicting method names.