### PR TITLE
fix: prepend_child causes negative order values when reordering within same parent

### DIFF
--- a/lib/closure_tree/hierarchy_maintenance.rb
+++ b/lib/closure_tree/hierarchy_maintenance.rb
@@ -49,7 +49,8 @@ module ClosureTree
           _ct_reorder_prior_siblings_if_parent_changed
           _ct_reorder_siblings
         elsif saved_changes[_ct.order_column_sym]
-          _ct_reorder_siblings(saved_changes[_ct.order_column_sym].min)
+          min = saved_changes[_ct.order_column_sym].min
+          _ct_reorder_siblings(min.negative? ? nil : min)
         end
       end
       if saved_changes[_ct.parent_column_name] && !@was_new_record

--- a/lib/closure_tree/numeric_deterministic_ordering.rb
+++ b/lib/closure_tree/numeric_deterministic_ordering.rb
@@ -135,7 +135,7 @@ module ClosureTree
     end
 
     def prepend_child(child_node)
-      child_node.order_value = -1
+      child_node.order_value = 0
       child_node.parent = self
       if child_node.save
         child_node.reload

--- a/lib/closure_tree/numeric_deterministic_ordering.rb
+++ b/lib/closure_tree/numeric_deterministic_ordering.rb
@@ -135,7 +135,7 @@ module ClosureTree
     end
 
     def prepend_child(child_node)
-      child_node.order_value = 0
+      child_node.order_value = -1
       child_node.parent = self
       if child_node.save
         child_node.reload

--- a/test/closure_tree/label_order_value_test.rb
+++ b/test/closure_tree/label_order_value_test.rb
@@ -38,6 +38,24 @@ class LabelOrderValueTest < ActiveSupport::TestCase
     assert_equal 1, c.reload.order_value
   end
 
+  test 'prepend_child should produce 0-based order values when reordering within the same parent' do
+    root = Label.create(name: 'root')
+    a = root.children.create(name: 'a')
+    b = root.children.create(name: 'b')
+    c = root.children.create(name: 'c')
+
+    assert_equal 0, a.order_value
+    assert_equal 1, b.order_value
+    assert_equal 2, c.order_value
+
+    # Move c to be the first child (same parent, reorder only)
+    root.prepend_child(c)
+
+    assert_equal 0, c.reload.order_value
+    assert_equal 1, a.reload.order_value
+    assert_equal 2, b.reload.order_value
+  end
+
   test 'should set order_value on roots for LabelWithoutRootOrdering' do
     root = LabelWithoutRootOrdering.create(name: 'root')
     assert_nil root.order_value


### PR DESCRIPTION
### Overview

This PR fixes a bug where `prepend_child` causes siblings to reorder with negative position values (-1, 0, 1, 2) instead of the correct 0-based values (0, 1, 2, 3) when moving a node to the first position within the same parent.

### Motivation

When `prepend_child` is called on a node that already belongs to the same parent, the `-1` sentinel value set on `order_value` was bleeding into the reorder formula in `_ct_after_save`. This caused:

- Siblings to be renumbered starting from `-1` instead of `0`
- All children of the affected parent to have incorrect position values
- The bug only happens in the same parent case. Cross parent moves trigger `rebuild!` which renumbers correctly.

### Root Cause

- `prepend_child` sets `order_value = -1` as a sentinel so the node sorts before all others in the SQL `ORDER BY`.
- `_ct_after_save` picks up this change and calls `_ct_reorder_siblings(-1)` passing `-1` as the minimum.
- `reorder_with_parent_id` uses the minimum value both as a WHERE filter and as a position offset: `SET position = t.seq + minimum - 1`
- With `minimum = -1`: `seq + (-1) - 1 = seq - 2`, producing `-1, 0, 1, 2` instead of `0, 1, 2, 3`

### Fix

In `_ct_after_save`, pass `nil` when the minimum changed value is negative:

```
elsif saved_changes[_ct.order_column_sym]
  min = saved_changes[_ct.order_column_sym].min
  _ct_reorder_siblings(min.negative? ? nil : min)
end
```

Passing `nil` removes the WHERE filter and resets the offset to `seq - 1`, producing correct 0-based positions. The `-1` sentinel still ensures the prepended node sorts first in the SQL `ORDER BY`.

### Behavior Change

- `prepend_child` on a same-parent node now produces correct 0-based positions
- Existing records already corrupted with `-1` positions will be fixed the next time any reorder is triggered within its scope. So no migration needed.

### Code Changes

`lib/closure_tree/hierarchy_maintenance.rb` — pass `nil` instead of negative minimum in `_ct_after_save`

### New Tests

`test/closure_tree/label_order_value_test.rb` - `prepend_child` should produce 0-based order values when reordering within the same parent

### Backward Compatibility

This is a bug fix. All existing reorder operations are unaffected. Only `prepend_child` within the same parent changes. It now produces correct 0-based positions instead of negative ones. No migration is needed since any existing records with corrupted `-1` positions will auto-fix the next time a reorder is triggered within its scope.