### PR TITLE
docs: Drop reference to closure_tree:config generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,6 @@ Note that closure_tree only supports ActiveRecord 7.2 and later, and has test co
 
     If you're starting from scratch you don't need to call `rebuild!`.
 
-NOTE: Run `rails g closure_tree:config` to create an initializer with extra
-      configurations. (Optional)
-
 ## Warning
 
 As stated above, using multiple hierarchy gems (like `ancestry` or `nested set`) on the same model


### PR DESCRIPTION
The closure_tree:config generator was removed as part of #457. See d18e80cdbd4f3510377363bc7b5166f0cc1b0a6f.

Fixes #493.